### PR TITLE
Allow hector server to be configured from the command line

### DIFF
--- a/bin/hector-daemon
+++ b/bin/hector-daemon
@@ -3,12 +3,18 @@
 require "hector/boot"
 Hector.start
 
+server_options = {
+  :port => ARGV[0],
+  :ssl_port => ARGV[1],
+  :address => ARGV[2],
+}
+
 if fork
   exec "tail -n 0 -f #{Hector.root.join("log/hector.log")}"
 else
   sleep 0.01
   EventMachine.run do
-    Hector.start_server
+    Hector.start_server server_options
   end
   Process.wait
 end

--- a/bin/hector-daemon
+++ b/bin/hector-daemon
@@ -3,18 +3,12 @@
 require "hector/boot"
 Hector.start
 
-server_options = {
-  :port => ARGV[0],
-  :ssl_port => ARGV[1],
-  :address => ARGV[2],
-}
-
 if fork
   exec "tail -n 0 -f #{Hector.root.join("log/hector.log")}"
 else
   sleep 0.01
   EventMachine.run do
-    Hector.start_server server_options
+    Hector.start_server
   end
   Process.wait
 end

--- a/lib/hector/server.rb
+++ b/lib/hector/server.rb
@@ -2,7 +2,11 @@ module Hector
   class << self
     attr_accessor :server_name
 
-    def start_server(address = "0.0.0.0", port = 6767, ssl_port = 6868)
+    def start_server(options)
+      address = options[:address] || "0.0.0.0"
+      port = options[:port] || 6767
+      ssl_port = options[:ssl_port] || 6868
+      
       EventMachine.start_server(address, port, Connection)
       EventMachine.start_server(address, ssl_port, SSLConnection)
       logger.info("Hector running on #{address}:#{port}")

--- a/lib/hector/server.rb
+++ b/lib/hector/server.rb
@@ -1,18 +1,17 @@
 module Hector
   class << self
-    attr_accessor :server_name
+    attr_accessor :server_name, :address, :port, :ssl_port
 
-    def start_server(options)
-      address = options[:address] || "0.0.0.0"
-      port = options[:port] || 6767
-      ssl_port = options[:ssl_port] || 6868
-      
-      EventMachine.start_server(address, port, Connection)
-      EventMachine.start_server(address, ssl_port, SSLConnection)
-      logger.info("Hector running on #{address}:#{port}")
-      logger.info("Secure Hector running on #{address}:#{ssl_port}")
+    def start_server
+      EventMachine.start_server(@address, @port, Connection)
+      EventMachine.start_server(@address, @ssl_port, SSLConnection)
+      logger.info("Hector running on #{@address}:#{@port}")
+      logger.info("Secure Hector running on #{@address}:#{@ssl_port}")
     end
   end
 
   self.server_name = "hector.irc"
+  self.address = "0.0.0.0"
+  self.port = 6767
+  self.ssl_port = 6868
 end


### PR DESCRIPTION
Allows a server administrator to adjust the address and ports from the command line tool
